### PR TITLE
feat(ci): add optional `pre-commit` for contributors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @stephansama
+/.pre-commit-config.yaml @DrKJeff16

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,11 @@ repos:
     rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
-
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:
       - id: remove-crlf
-      - id: forbid-crlf  # Forbid files containing CRLF end-lines to be committed
-
+      - id: forbid-crlf # Forbid files containing CRLF end-lines to be committed
   - repo: local
     hooks:
       - id: make_lint
@@ -18,7 +16,6 @@ repos:
         entry: make lint
         files: '^(plugin|lua)/.*\.lua$'
         verbose: true
-
       - id: make_docs
         name: Generate Docs
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.5
+    hooks:
+      - id: remove-crlf
+      - id: forbid-crlf  # Forbid files containing CRLF end-lines to be committed
+
+  - repo: local
+    hooks:
+      - id: make_lint
+        name: Run Linters
+        language: system
+        entry: make lint
+        verbose: true
+
+      - id: make_docs
+        name: Generate Docs
+        language: system
+        entry: make documentation-ci
+        verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,12 @@ repos:
         name: Run Linters
         language: system
         entry: make lint
+        files: '^(plugin|lua)/.*\.lua$'
         verbose: true
 
       - id: make_docs
         name: Generate Docs
         language: system
         entry: make documentation-ci
+        files: '^(plugin|lua)/.*\.lua$'
         verbose: true

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test-0.8.3:
 # installs `mini.nvim`, used for both the tests and documentation.
 deps:
 	@mkdir -p deps
-	git clone --depth 1 https://github.com/echasnovski/mini.nvim deps/mini.nvim
+	git clone --depth 1 https://github.com/nvim-mini/mini.nvim ./deps/mini.nvim
 
 # installs deps before running tests, useful for the CI.
 test-ci: deps test

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
+"pre-commit" = "latest"
 "cargo:selene" = "latest"

--- a/plugin/fzf-nerdfont.lua
+++ b/plugin/fzf-nerdfont.lua
@@ -1,4 +1,3 @@
--- You can use this loaded variable to enable conditional parts of your plugin.
 if vim.g.fzf_nerd_font_loaded == 1 then
     return
 end


### PR DESCRIPTION
## 📃 Summary

I regularly use [`pre-commit`](https://pre-commit.com/) to improve my workflow.

This tool installs hooks that will be executed right when you commit. If any of those hooks fails, you'll have to check what causes it.

Useful for linters, StyLua, docs generation, and much more.

## 📸 Preview

_NONE._
