### PR TITLE
fix: improved `Makefile`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           neovim: true
           version: v0.11.3
       - name: Generate Docs
-        run: make documentation-ci
+        run: make documentation
       - name: Check Docs Diff
         run: exit $(git status --porcelain doc | wc -l | tr -d " ")
   tests:
@@ -77,9 +77,9 @@ jobs:
         run: |
           export PATH="${PWD}/.ci/lua-ls/bin:${PATH}"
           nvim --version
-          make luals-ci
+          make luals
       - name: Run Tests
-        run: make test-ci
+        run: make test
   tests-nightly:
     name: Test on Neovim Nightly
     runs-on: ubuntu-latest
@@ -115,9 +115,9 @@ jobs:
         run: |
           export PATH="${PWD}/.ci/lua-ls/bin:${PATH}"
           nvim --version
-          make luals-ci
+          make luals
       - name: Run Tests
-        run: make test-ci
+        run: make test
   release:
     name: Release
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,6 @@ repos:
       - id: make_docs
         name: Generate Docs
         language: system
-        entry: make documentation-ci
+        entry: make documentation
         files: '^(plugin|lua)/.*\.lua$'
         verbose: true

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ test-0.8.3:
 	bob use 0.8.3
 	$(MAKE) test
 
-# cleans the `deps/` directory, useful for resetting the environment.
+# cleans the `deps/` and `.ci/` directories, useful for resetting the environment.
 clean:
-	rm -rf deps
+	rm -rf deps .ci
 
 # installs deps, then generates documentation.
 documentation: deps/mini

--- a/Makefile
+++ b/Makefile
@@ -1,56 +1,53 @@
+.POSIX:
+
 .SUFFIXES:
 
-.PHONY: all test-nightly test-0.8.3 test documentation documentation-ci lint luals-ci luals update_glyphs setup
+.PHONY: all clean deps test-nightly test-0.8.3 test documentation lint luals update_glyphs setup
 
 all: documentation lint luals test
 
+# installs `mini.nvim` and LuaLS.
+deps:
+	@mkdir -p .ci/lua-ls
+	curl -sL "https://github.com/LuaLS/lua-language-server/releases/download/3.7.4/lua-language-server-3.7.4-darwin-x64.tar.gz" | tar xzf - -C "${PWD}/.ci/lua-ls"
+	[ -d ./deps/mini.nvim ] || git clone --depth 1 https://github.com/nvim-mini/mini.nvim ./deps/mini.nvim
+
 # runs all the test files.
-test:
-	make deps
+test: deps
 	nvim --version | head -n 1 && echo ''
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
 		-c "lua require('mini.test').setup()" \
 		-c "lua MiniTest.run({ execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
 
 # runs all the test files on the nightly version, `bob` must be installed.
-test-nightly:
+test-nightly: deps
 	bob use nightly
 	make test
 
 # runs all the test files on the 0.8.3 version, `bob` must be installed.
-test-0.8.3:
+test-0.8.3: deps
 	bob use 0.8.3
 	make test
 
-# installs `mini.nvim`, used for both the tests and documentation.
-deps:
-	@mkdir -p deps
-	git clone --depth 1 https://github.com/nvim-mini/mini.nvim ./deps/mini.nvim
+# cleans the `deps/` directory, useful for resetting the environment.
+clean:
+	rm -rf deps
 
-# installs deps before running tests, useful for the CI.
-test-ci: deps test
-
-# generates the documentation.
-documentation:
-	nvim --headless --noplugin -u ./scripts/minimal_init.lua -c "lua require('mini.doc').generate()" -c "qa!"
-
-# installs deps before running the documentation generation, useful for the CI.
-documentation-ci: deps documentation
+# installs deps, then generates documentation.
+documentation: deps
+	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
+		-c "lua require('mini.doc').generate()" \
+		-c "qa!"
 
 # performs a lint check and fixes issue if possible, following the config in `stylua.toml`.
 lint:
 	stylua . -g '*.lua' -g '!deps/' -g '!nightly/'
 	selene plugin/ lua/
 
-luals-ci:
+luals: deps
 	rm -rf .ci/lua-ls/log
 	lua-language-server --configpath .luarc.json --logpath .ci/lua-ls/log --check .
 	[ -f .ci/lua-ls/log/check.json ] && { cat .ci/lua-ls/log/check.json 2>/dev/null; exit 1; } || true
-
-luals:
-	mkdir -p .ci/lua-ls
-	curl -sL "https://github.com/LuaLS/lua-language-server/releases/download/3.7.4/lua-language-server-3.7.4-darwin-x64.tar.gz" | tar xzf - -C "${PWD}/.ci/lua-ls"
-	make luals-ci
 
 update_glyphs:
 	./scripts/update_glyphs.sh

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,14 @@
 
 all: documentation lint luals test
 
+deps: deps/mini deps/luals
+
 # installs `mini.nvim` and LuaLS.
-deps:
-	@mkdir -p .ci/lua-ls
-	curl -sL "https://github.com/LuaLS/lua-language-server/releases/download/3.7.4/lua-language-server-3.7.4-darwin-x64.tar.gz" | tar xzf - -C "${PWD}/.ci/lua-ls"
-	[ -d ./deps/mini.nvim ] || git clone --depth 1 https://github.com/nvim-mini/mini.nvim ./deps/mini.nvim
+deps/mini:
+	./scripts/deps.sh mini
+
+deps/luals:
+	./scripts/deps.sh luals
 
 # runs all the test files.
 test: deps
@@ -45,7 +48,6 @@ lint:
 	selene plugin/ lua/
 
 luals: deps
-	rm -rf .ci/lua-ls/log
 	lua-language-server --configpath .luarc.json --logpath .ci/lua-ls/log --check .
 	[ -f .ci/lua-ls/log/check.json ] && { cat .ci/lua-ls/log/check.json 2>/dev/null; exit 1; } || true
 

--- a/Makefile
+++ b/Makefile
@@ -2,42 +2,43 @@
 
 .SUFFIXES:
 
-.PHONY: all clean deps test-nightly test-0.8.3 test documentation lint luals update_glyphs setup
+.PHONY: all clean deps deps/mini deps/luals test-nightly test-0.8.3 test documentation lint luals update_glyphs setup
 
 all: documentation lint luals test
 
 deps: deps/mini deps/luals
 
-# installs `mini.nvim` and LuaLS.
+# installs `mini.nvim`.
 deps/mini:
 	./scripts/deps.sh mini
 
+# installs `LuaLS`.
 deps/luals:
 	./scripts/deps.sh luals
 
 # runs all the test files.
-test: deps
+test: deps/mini
 	nvim --version | head -n 1 && echo ''
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
 		-c "lua require('mini.test').setup()" \
 		-c "lua MiniTest.run({ execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
 
 # runs all the test files on the nightly version, `bob` must be installed.
-test-nightly: deps
+test-nightly:
 	bob use nightly
-	make test
+	$(MAKE) test
 
 # runs all the test files on the 0.8.3 version, `bob` must be installed.
-test-0.8.3: deps
+test-0.8.3:
 	bob use 0.8.3
-	make test
+	$(MAKE) test
 
 # cleans the `deps/` directory, useful for resetting the environment.
 clean:
 	rm -rf deps
 
 # installs deps, then generates documentation.
-documentation: deps
+documentation: deps/mini
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
 		-c "lua require('mini.doc').generate()" \
 		-c "qa!"
@@ -47,7 +48,7 @@ lint:
 	stylua . -g '*.lua' -g '!deps/' -g '!nightly/'
 	selene plugin/ lua/
 
-luals: deps
+luals: deps/luals
 	lua-language-server --configpath .luarc.json --logpath .ci/lua-ls/log --check .
 	[ -f .ci/lua-ls/log/check.json ] && { cat .ci/lua-ls/log/check.json 2>/dev/null; exit 1; } || true
 

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+[[ $# -eq 0 ]] && exit 127
+
+DEP="$1"
+LUALS_URL="https://github.com/LuaLS/lua-language-server/releases/download/3.7.4/lua-language-server-3.7.4-darwin-x64.tar.gz"
+
+__get_mini() {
+	if ! [ -d ./deps/mini.nvim ]; then
+	    git clone --depth 1 https://github.com/nvim-mini/mini.nvim deps/mini.nvim || return 1
+	fi
+
+	return 0
+}
+
+__get_lua_ls() {
+    if [[ -d .ci/lua-ls ]]; then
+        rm -rf .ci/lua-ls/log
+        return 0
+    fi
+
+    mkdir -p .ci/lua-ls
+	curl -sL "$LUALS_URL" tar xzf - -C "$(pwd)/.ci/lua-ls"
+    return $?
+}
+
+case "$DEP" in
+    [Mm][Ii][Nn][Ii]) __get_mini; exit $? ;;
+    [Ll][Uu][Aa][Ll][Ss]) __get_lua_ls; exit $? ;;
+    *) exit 1 ;;
+esac

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -19,7 +19,7 @@ __get_lua_ls() {
         return 0
     fi
 
-	printf "%s\n" "mkdir -p .ci/lua-ls" "curl -sL \"\$LUALS_URL\" tar xzf - -C \"\$(pwd)/.ci/lua-ls"
+	printf "%s\n" "mkdir -p .ci/lua-ls" "curl -sL \"\$LUALS_URL\" | tar xzf - -C \"\$(pwd)/.ci/lua-ls\""
 
     mkdir -p .ci/lua-ls
 	curl -sL "$LUALS_URL" | tar xzf - -C "$(pwd)/.ci/lua-ls"

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -7,20 +7,23 @@ LUALS_URL="https://github.com/LuaLS/lua-language-server/releases/download/3.7.4/
 
 __get_mini() {
 	if ! [ -d ./deps/mini.nvim ]; then
+        printf "git clone --depth 1 https://github.com/nvim-mini/mini.nvim deps/mini.nvim\n"
 	    git clone --depth 1 https://github.com/nvim-mini/mini.nvim deps/mini.nvim || return 1
 	fi
-
 	return 0
 }
 
 __get_lua_ls() {
     if [[ -d .ci/lua-ls ]]; then
-        rm -rf .ci/lua-ls/log
+        printf "rm -rf .ci/lua-ls/log\n"
         return 0
     fi
 
+	printf "%s\n" "mkdir -p .ci/lua-ls" "curl -sL \"\$LUALS_URL\" tar xzf - -C \"\$(pwd)/.ci/lua-ls"
+
     mkdir -p .ci/lua-ls
 	curl -sL "$LUALS_URL" tar xzf - -C "$(pwd)/.ci/lua-ls"
+
     return $?
 }
 

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -22,7 +22,7 @@ __get_lua_ls() {
 	printf "%s\n" "mkdir -p .ci/lua-ls" "curl -sL \"\$LUALS_URL\" tar xzf - -C \"\$(pwd)/.ci/lua-ls"
 
     mkdir -p .ci/lua-ls
-	curl -sL "$LUALS_URL" tar xzf - -C "$(pwd)/.ci/lua-ls"
+	curl -sL "$LUALS_URL" | tar xzf - -C "$(pwd)/.ci/lua-ls"
 
     return $?
 }

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -6,23 +6,24 @@ DEP="$1"
 LUALS_URL="https://github.com/LuaLS/lua-language-server/releases/download/3.7.4/lua-language-server-3.7.4-darwin-x64.tar.gz"
 
 __get_mini() {
-	if ! [ -d ./deps/mini.nvim ]; then
+    if ! [ -d ./deps/mini.nvim ]; then
         printf "git clone --depth 1 https://github.com/nvim-mini/mini.nvim deps/mini.nvim\n"
-	    git clone --depth 1 https://github.com/nvim-mini/mini.nvim deps/mini.nvim || return 1
-	fi
-	return 0
+        git clone --depth 1 https://github.com/nvim-mini/mini.nvim deps/mini.nvim || return 1
+    fi
+    return 0
 }
 
 __get_lua_ls() {
     if [[ -d .ci/lua-ls ]]; then
         printf "rm -rf .ci/lua-ls/log\n"
+        rm -rf .ci/lua-ls/log
         return 0
     fi
 
 	printf "%s\n" "mkdir -p .ci/lua-ls" "curl -sL \"\$LUALS_URL\" | tar xzf - -C \"\$(pwd)/.ci/lua-ls\""
 
     mkdir -p .ci/lua-ls
-	curl -sL "$LUALS_URL" | tar xzf - -C "$(pwd)/.ci/lua-ls"
+    curl -sL "$LUALS_URL" | tar xzf - -C "$(pwd)/.ci/lua-ls"
 
     return $?
 }


### PR DESCRIPTION
## 📃 Summary

- Removed all the `-cli` rules (redundant)
- New `.POSIX:`  directive for multi-platform support
- Created `scripts/deps.sh` to aid with dependency generation
- New rules:
	- `deps/mini` for `mini.nvim` installation
	- `deps/luals` for `LuaLS` installation
- `deps` is now a wrapper for the new rules mentioned above
- Replaced all explicit `make` calls with `$(MAKE)` (it's good practice)

## 📸 Preview

_NONE._
