### PR TITLE
chore: updated `CODEOWNERS` with correct attribution

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Maintainer
 * @stephansama
+
+# Patching and CI
 /.pre-commit-config.yaml @DrKJeff16
 /scripts/deps.sh @DrKJeff16

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @stephansama
 /.pre-commit-config.yaml @DrKJeff16
+/scripts/deps.sh @DrKJeff16


### PR DESCRIPTION
## 📃 Summary

Added correct `CODEOWNERS` attribution for `scripts/deps.sh`.

## 📸 Preview

_NONE._
